### PR TITLE
Use node props for node categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "@codemirror/next": "0.11.0",
         "lezer": "0.10.3",
-        "lezer-generator": "0.10.3",
+        "lezer-generator": "0.10.4",
         "lezer-tree": "0.10.0",
         "platform": "1.3.5",
         "react": "16.13.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "@codemirror/next": "0.11.0",
         "lezer": "0.10.3",
-        "lezer-generator": "0.10.2",
+        "lezer-generator": "0.10.3",
         "lezer-tree": "0.10.0",
         "platform": "1.3.5",
         "react": "16.13.0",

--- a/src/main/codemirror_next/clojure.cljs
+++ b/src/main/codemirror_next/clojure.cljs
@@ -54,7 +54,7 @@
                        (.add syntax/foldNodeProp fold-node-props)
                        (highlight/styleTags style-tags))))
 
-(def clj-keymap (view/keymap (keymap/ungroup keymap/default-keymap)))
+(def clj-keymap (keymap/ungroup keymap/default-keymap))
 
 (def clj-extensions #js[clojure-syntax-ext
                         close-brackets/extension
@@ -64,7 +64,7 @@
 (comment
 
   (let [state (test-utils/make-state #js[clj-extensions
-                                         clj-keymap]
+                                         (view/keymap clj-keymap)]
                                      "[[]|")
         from (.. state -selection -primary -from)]
     (some->>

--- a/src/main/codemirror_next/clojure.cljs
+++ b/src/main/codemirror_next/clojure.cljs
@@ -23,7 +23,11 @@
 
 (def parser
   (lg/buildParser
-   (rc/inline "./clojure/clojure.grammar")))
+   (rc/inline "./clojure/clojure.grammar")
+   #js{:externalProp (fn [prop-name]
+                       (prn :exprop prop-name)
+                       (case prop-name
+                         "prefix" (.flag lz-tree/NodeProp)))}))
 
 (def fold-node-props
   (let [coll-span (fn [^js tree] #js{:from (inc (.-start tree))
@@ -52,7 +56,8 @@
            (.withProps parser
                        format/props
                        (.add syntax/foldNodeProp fold-node-props)
-                       (highlight/styleTags style-tags))
+                       (highlight/styleTags style-tags)
+                       )
            (j/lit {:closeBrackets {:brackets [\( \[ \{ \' \"]
                                    :commentTokens {:line ";;"}}})))
 

--- a/src/main/codemirror_next/clojure.cljs
+++ b/src/main/codemirror_next/clojure.cljs
@@ -24,11 +24,8 @@
 (def parser
   (lg/buildParser
    (rc/inline "./clojure/clojure.grammar")
-   #js{:externalProp (fn [prop-name]
-                       (prn :exprop prop-name)
-                       (case prop-name
-                         "prefix" (.flag lz-tree/NodeProp)))}))
-
+   #js{:externalProp n/node-prop}))
+(js/console.log parser)
 (def fold-node-props
   (let [coll-span (fn [^js tree] #js{:from (inc (.-start tree))
                                      :to (dec (.-end tree))})]

--- a/src/main/codemirror_next/clojure.cljs
+++ b/src/main/codemirror_next/clojure.cljs
@@ -23,9 +23,9 @@
 
 (def parser
   (lg/buildParser
-   (rc/inline "./clojure/clojure.grammar")
-   #js{:externalProp n/node-prop}))
-(js/console.log parser)
+    (rc/inline "./clojure/clojure.grammar")
+    #js{:externalProp n/node-prop}))
+
 (def fold-node-props
   (let [coll-span (fn [^js tree] #js{:from (inc (.-start tree))
                                      :to (dec (.-end tree))})]

--- a/src/main/codemirror_next/clojure.cljs
+++ b/src/main/codemirror_next/clojure.cljs
@@ -18,7 +18,8 @@
             [codemirror-next.clojure.node :as n]
             [codemirror-next.clojure.selections :as sel]
             [codemirror-next.test-utils :as test-utils]
-            [shadow.resource :as rc])
+            [shadow.resource :as rc]
+            [codemirror-next.clojure.util :as u])
   (:require-macros [codemirror-next.build :as build]))
 
 (def parser
@@ -71,3 +72,17 @@
 (defn state [content & [extensions]]
   (.create EditorState #js{:doc content
                            :extensions (or extensions default-extensions)}))
+
+(comment
+  (aset js/window "n" lz-tree/NodeProp)
+  (let [state (test-utils/make-state default-extensions
+                       "[[]|")
+        from (.. state -selection -primary -from)]
+    (some->>
+      (n/tree state from -1)
+      (n/ancestors)
+      (filter (complement n/balanced?))
+      first
+      n/down
+      n/closed-by
+      )))

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -64,7 +64,7 @@ Operator { !operator Symbol }
   "#^"[prefixEdge]
   "#_"[prefixEdge]
 
-  '"'[sameEdge, closedBy='"']
+  '"'[sameEdge, closedBy='"', openedBy='"']
   "'"[prefixEdge]
   "`"[prefixEdge]
   "~"[prefixEdge]

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -1,4 +1,9 @@
-@external prop myProp from "./props"
+@external prop prefix from "./props"
+@external prop coll from "./props"
+@external prop startEdge from "./props"
+@external prop endEdge from "./props"
+@external prop prefixEdge from "./props"
+@external prop sameEdge from "./props"
 
 @top[name=Program] { expression* }
 
@@ -13,31 +18,32 @@ listContents {
  }
 
 DocString { !docString String }
-List { "(" listContents ")" }
-Vector { "[" expression* "]" }
-Map { "{" expression* "}" }
+List[coll] { "(" listContents ")" }
+Vector[coll] { "[" expression* "]" }
+Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
 @skip {} {
-  Set[myProp=true] { "#" Map }
-  AnonymousFunction { "#" List }
-  NamespacedMap { "#" KeywordPrefix Map }
-  RegExp { "#" String }
-  Var { "#'" Symbol }
-  ReaderConditional { "#?" (List | Deref) }
-  DataLiteral { "#" ident }
-  SymbolicValue { "##" simpleIdent }
-  Metadata { ("^" | "#^") expression }
-  String { '"' StringContent? '"' }
+  Set[prefix] { "#" Map }
+  AnonymousFunction[prefix] { "#" List }
+  NamespacedMap[prefix] { "#" KeywordPrefix Map }
+  RegExp[prefix] { "#" String }
+  Var[prefix] { "#'" Symbol }
+  ReaderConditional[prefix] { "#?" (List | Deref) }
+  DataLiteral[prefix] { "#" ident }
+  SymbolicValue[prefix] { "##" simpleIdent }
+  ReaderMetadata[prefix] { "#^" expression }
+  Metadata[prefix] { "^" expression }
+  String[prefix] { '"' StringContent? '"' }
 }
 
 Meta<t> { Metadata !meta t }
 
-Deref { "@" expression }
-Quote { "'" expression }
-SyntaxQuote { "`" expression }
-Unquote { "~" expression }
-UnquoteSplice { "~@" expression }
+Deref[prefix] { "@" expression }
+Quote[prefix] { "'" expression }
+SyntaxQuote[prefix] { "`" expression }
+Unquote[prefix] { "~" expression }
+UnquoteSplice[prefix] { "~@" expression }
 operatorWithMeta { Operator | Meta<operatorWithMeta> }
 defLikeWithMeta { DefLike | Meta<defLikeWithMeta> }
 varNameWithMeta { VarName | Meta<varNameWithMeta> }
@@ -47,29 +53,29 @@ Operator { !operator Symbol }
 @tokens {
 
 
-  "["
-  "{"
-  "("
+  "["[startEdge]
+  "{"[startEdge]
+  "("[startEdge]
 
-  "#"
-  "##"
-  "#'"
-  "#?"
-  "#^"
-  "#_"
+  "#"[prefixEdge]
+  "##"[prefixEdge]
+  "#'"[prefixEdge]
+  "#?"[prefixEdge]
+  "#^"[prefixEdge]
+  "#_"[prefixEdge]
 
-  '"'
-  "'"
-  "`"
-  "~"
-  "~@"
-  "^"
-  "@"
+  '"'[sameEdge, closedBy='"']
+  "'"[prefixEdge]
+  "`"[prefixEdge]
+  "~"[prefixEdge]
+  "~@"[prefixEdge]
+  "^"[prefixEdge]
+  "@"[prefixEdge]
 
 
-  "]"
-  "}"
-  ")"
+  "]"[endEdge]
+  "}"[endEdge]
+  ")"[endEdge]
 
   whitespace { (std.whitespace | ",")+ }
 
@@ -84,7 +90,7 @@ Operator { !operator Symbol }
 
   keyword { ":" ":"? ident }
   Keyword { keyword }
-  KeywordPrefix { keyword }
+  KeywordPrefix[prefixEdge] { keyword }
 
   Number {
     ("+" | "-")? (std.digit+ ("." std.digit* "M"?)? | "." std.digit+) (("e" | "E") ("+" | "-")? std.digit+ "M"?)? |

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -1,3 +1,5 @@
+@external prop myProp from "./props"
+
 @top[name=Program] { expression* }
 
 @skip { whitespace | LineComment | Discard }
@@ -17,7 +19,7 @@ Map { "{" expression* "}" }
 VarName { Symbol }
 
 @skip {} {
-  Set { "#" Map }
+  Set[myProp=true] { "#" Map }
   AnonymousFunction { "#" List }
   NamespacedMap { "#" KeywordPrefix Map }
   RegExp { "#" String }

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -34,10 +34,10 @@ VarName { Symbol }
   SymbolicValue[prefix] { "##" simpleIdent }
   ReaderMetadata[prefix] { "#^" expression }
   Metadata[prefix] { "^" expression }
-  String[prefix] { '"' StringContent? '"' }
+  String { '"' StringContent? '"' }
 }
 
-Meta<t> { Metadata !meta t }
+Meta<t> { (Metadata | ReaderMetadata) !meta t }
 
 Deref[prefix] { "@" expression }
 Quote[prefix] { "'" expression }

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -1,4 +1,4 @@
-@external prop prefix from "./props"
+@external prop prefixColl from "./props"
 @external prop coll from "./props"
 @external prop startEdge from "./props"
 @external prop endEdge from "./props"
@@ -24,26 +24,26 @@ Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
 @skip {} {
-  Set[prefix] { "#" Map }
-  AnonymousFunction[prefix] { "#" List }
-  NamespacedMap[prefix] { "#" KeywordPrefix Map }
-  RegExp[prefix] { "#" String }
-  Var[prefix] { "#'" Symbol }
-  ReaderConditional[prefix] { "#?" (List | Deref) }
-  DataLiteral[prefix] { "#" ident }
-  SymbolicValue[prefix] { "##" simpleIdent }
-  ReaderMetadata[prefix] { "#^" expression }
-  Metadata[prefix] { "^" expression }
+  Set[prefixColl] { "#" Map }
+  AnonymousFunction[prefixColl] { "#" List }
+  NamespacedMap[prefixColl] { "#" KeywordPrefix Map }
+  RegExp[prefixColl] { "#" String }
+  Var[prefixColl] { "#'" Symbol }
+  ReaderConditional[prefixColl] { "#?" (List | Deref) }
+  DataLiteral[prefixColl] { "#" ident }
+  SymbolicValue[prefixColl] { "##" simpleIdent }
+  ReaderMetadata[prefixColl] { "#^" expression }
+  Metadata[prefixColl] { "^" expression }
   String { '"' StringContent? '"' }
 }
 
 Meta<t> { (Metadata | ReaderMetadata) !meta t }
 
-Deref[prefix] { "@" expression }
-Quote[prefix] { "'" expression }
-SyntaxQuote[prefix] { "`" expression }
-Unquote[prefix] { "~" expression }
-UnquoteSplice[prefix] { "~@" expression }
+Deref[prefixColl] { "@" expression }
+Quote[prefixColl] { "'" expression }
+SyntaxQuote[prefixColl] { "`" expression }
+Unquote[prefixColl] { "~" expression }
+UnquoteSplice[prefixColl] { "~@" expression }
 operatorWithMeta { Operator | Meta<operatorWithMeta> }
 defLikeWithMeta { DefLike | Meta<defLikeWithMeta> }
 varNameWithMeta { VarName | Meta<varNameWithMeta> }

--- a/src/main/codemirror_next/clojure/clojure.grammar
+++ b/src/main/codemirror_next/clojure/clojure.grammar
@@ -1,7 +1,5 @@
 @external prop prefixColl from "./props"
 @external prop coll from "./props"
-@external prop startEdge from "./props"
-@external prop endEdge from "./props"
 @external prop prefixEdge from "./props"
 @external prop sameEdge from "./props"
 
@@ -53,9 +51,9 @@ Operator { !operator Symbol }
 @tokens {
 
 
-  "["[startEdge]
-  "{"[startEdge]
-  "("[startEdge]
+  "["
+  "{"
+  "("
 
   "#"[prefixEdge]
   "##"[prefixEdge]
@@ -73,9 +71,9 @@ Operator { !operator Symbol }
   "@"[prefixEdge]
 
 
-  "]"[endEdge]
-  "}"[endEdge]
-  ")"[endEdge]
+  "]"
+  "}"
+  ")"
 
   whitespace { (std.whitespace | ",")+ }
 

--- a/src/main/codemirror_next/clojure/commands.cljs
+++ b/src/main/codemirror_next/clojure/commands.cljs
@@ -66,6 +66,7 @@
 (defn nav-position [state from dir]
   (or (some-> (n/closest (n/tree state from)
                          #(or (n/coll? %)
+                              (n/string? %)
                               (n/top? %)))
               (n/children from dir)
               first

--- a/src/main/codemirror_next/clojure/commands.cljs
+++ b/src/main/codemirror_next/clojure/commands.cljs
@@ -34,8 +34,8 @@
       (or (when empty
             (let [node (n/tree state from)
                   parent (n/closest node #(or (n/coll? %)
-                                              (= "String" (n/name %))
-                                              (= "Program" (n/name %))))
+                                              (n/string? %)
+                                              (n/top? %)))
                   line-end (.-to (.lineAt (.-doc state) from))
                   next-children (when parent (n/children parent from 1))
                   last-child-on-line
@@ -49,7 +49,7 @@
                                                  (if (neg? next-newline)
                                                    (dec (n/end parent))
                                                    (+ from next-newline 1)))
-                            last-child-on-line (if (n/end-edge-node? last-child-on-line)
+                            last-child-on-line (if (n/end-edge? last-child-on-line)
                                                  (n/start last-child-on-line)
                                                  (n/end last-child-on-line))
                             (some-> (first next-children)
@@ -98,11 +98,11 @@
                   (u/guard (j/fn [^:js {:as what :keys [start]}]
                              (= pos start))))
         mid (n/tree state pos)]
-    (case dir 1 (or (u/guard R (every-pred some? (complement n/right-edge-node?)))
+    (case dir 1 (or (u/guard R (every-pred some? (complement n/right-edge?)))
                     L
                     R
                     mid)
-              -1 (or (u/guard L (every-pred some? (complement n/left-edge-node?)))
+              -1 (or (u/guard L (every-pred some? (complement n/left-edge?)))
                      R
                      L
                      mid))))
@@ -147,8 +147,8 @@
       (j/fn [^:js {:as range :keys [from to empty]}]
         (when empty
           (when-let [parent (n/closest (n/tree state from) (every-pred n/coll?
-                                                                          #(not (case direction 1 (some-> % n/with-prefix n/right n/end-edge-node?)
-                                                                                                -1 (some-> % n/with-prefix n/left n/start-edge-node?)))))]
+                                                                       #(not (case direction 1 (some-> % n/with-prefix n/right n/end-edge?)
+                                                                                             -1 (some-> % n/with-prefix n/left n/start-edge?)))))]
             (when-let [target (case direction 1 (first (remove n/line-comment? (n/rights (n/with-prefix parent))))
                                               -1 (first (remove n/line-comment? (n/lefts (n/with-prefix parent)))))]
               {:cursor/mapped from

--- a/src/main/codemirror_next/clojure/commands.cljs
+++ b/src/main/codemirror_next/clojure/commands.cljs
@@ -49,7 +49,7 @@
                                                  (if (neg? next-newline)
                                                    (dec (n/end parent))
                                                    (+ from next-newline 1)))
-                            last-child-on-line (if (n/closing-bracket? last-child-on-line)
+                            last-child-on-line (if (n/end-edge-node? last-child-on-line)
                                                  (n/start last-child-on-line)
                                                  (n/end last-child-on-line))
                             (some-> (first next-children)
@@ -98,11 +98,11 @@
                   (u/guard (j/fn [^:js {:as what :keys [start]}]
                              (= pos start))))
         mid (n/tree state pos)]
-    (case dir 1 (or (u/guard R (every-pred some? (complement n/right-edge?)))
+    (case dir 1 (or (u/guard R (every-pred some? (complement n/right-edge-node?)))
                     L
                     R
                     mid)
-              -1 (or (u/guard L (every-pred some? (complement n/left-edge?)))
+              -1 (or (u/guard L (every-pred some? (complement n/left-edge-node?)))
                      R
                      L
                      mid))))
@@ -147,8 +147,8 @@
       (j/fn [^:js {:as range :keys [from to empty]}]
         (when empty
           (when-let [parent (n/closest (n/tree state from) (every-pred n/coll?
-                                                                          #(not (case direction 1 (some-> % n/with-prefix n/right n/closing-bracket?)
-                                                                                                -1 (some-> % n/with-prefix n/left n/opening-bracket?)))))]
+                                                                          #(not (case direction 1 (some-> % n/with-prefix n/right n/end-edge-node?)
+                                                                                                -1 (some-> % n/with-prefix n/left n/start-edge-node?)))))]
             (when-let [target (case direction 1 (first (remove n/line-comment? (n/rights (n/with-prefix parent))))
                                               -1 (first (remove n/line-comment? (n/lefts (n/with-prefix parent)))))]
               {:cursor/mapped from

--- a/src/main/codemirror_next/clojure/demo.cljs
+++ b/src/main/codemirror_next/clojure/demo.cljs
@@ -1,6 +1,6 @@
 (ns codemirror-next.clojure.demo
   (:require ["@codemirror/next/closebrackets" :refer [closeBrackets]]
-            ["@codemirror/next/fold" :refer [foldGutter foldKeymap]]
+            ["@codemirror/next/fold" :as fold]
             ["@codemirror/next/gutter" :refer [lineNumbers]]
             ["@codemirror/next/highlight" :as highlight]
             ["@codemirror/next/history" :refer [history]]
@@ -24,13 +24,16 @@
             [shadow.resource :as rc])
   (:require-macros [codemirror-next.build :as build]))
 
-(def extensions (-> #js[(history)
-                        (bracketMatching)
-                        highlight/defaultHighlighter
-                        (view/multipleSelections)]
-                    (.concat
-                      cm-clj/clj-extensions
-                      #js[(view/keymap cm-clj/clj-keymap)])))
+(defonce extensions (-> #js[(history)
+                            (bracketMatching)
+                            highlight/defaultHighlighter
+                            (view/multipleSelections)
+                            (lineNumbers)
+                            (fold/foldGutter)]
+                        (.concat
+                          cm-clj/clj-extensions
+                          #js[(view/keymap
+                                (.concat cm-clj/clj-keymap))])))
 
 (defn sample-text []
   (str "(defn lezer-clojure

--- a/src/main/codemirror_next/clojure/demo.cljs
+++ b/src/main/codemirror_next/clojure/demo.cljs
@@ -22,6 +22,14 @@
             [shadow.resource :as rc])
   (:require-macros [codemirror-next.build :as build]))
 
+(def extensions (-> #js[(history)
+                        (bracketMatching)
+                        highlight/defaultHighlighter
+                        (multipleSelections)]
+                    (.concat
+                      cm-clj/clj-extensions
+                      #js[cm-clj/clj-keymap])))
+
 (defn sample-text []
   (str "(defn lezer-clojure
   \"This is a showcase for `lezer-clojure`, an grammar for Clojure/Script to
@@ -50,7 +58,7 @@
 (defonce prev-views (atom []))
 
 (defn mount-editor! [dom-selector initial-value]
-  (let [state (test-utils/make-state cm-clj/default-extensions initial-value)]
+  (let [state (test-utils/make-state extensions initial-value)]
     (->> (j/obj :state state :parent (js/document.querySelector dom-selector))
          (new EditorView)
          (swap! prev-views conj))))

--- a/src/main/codemirror_next/clojure/demo.cljs
+++ b/src/main/codemirror_next/clojure/demo.cljs
@@ -1,11 +1,13 @@
 (ns codemirror-next.clojure.demo
   (:require ["@codemirror/next/closebrackets" :refer [closeBrackets]]
+            ["@codemirror/next/fold" :refer [foldGutter foldKeymap]]
+            ["@codemirror/next/gutter" :refer [lineNumbers]]
             ["@codemirror/next/highlight" :as highlight]
             ["@codemirror/next/history" :refer [history]]
             ["@codemirror/next/matchbrackets" :refer [bracketMatching]]
             ["@codemirror/next/state" :refer [EditorState]]
             ["@codemirror/next/syntax" :as syntax]
-            ["@codemirror/next/view" :refer [EditorView keymap multipleSelections]]
+            ["@codemirror/next/view" :as view :refer [EditorView]]
             ["lezer" :as lezer]
             ["lezer-generator" :as lg]
             ["lezer-tree" :as lz-tree]
@@ -25,10 +27,10 @@
 (def extensions (-> #js[(history)
                         (bracketMatching)
                         highlight/defaultHighlighter
-                        (multipleSelections)]
+                        (view/multipleSelections)]
                     (.concat
                       cm-clj/clj-extensions
-                      #js[cm-clj/clj-keymap])))
+                      #js[(view/keymap cm-clj/clj-keymap)])))
 
 (defn sample-text []
   (str "(defn lezer-clojure

--- a/src/main/codemirror_next/clojure/extensions/close_brackets.cljs
+++ b/src/main/codemirror_next/clojure/extensions/close_brackets.cljs
@@ -39,11 +39,12 @@
                     (and parent (not (n/balanced? parent))) nil
 
                     ;; entering right edge of collection - skip
-                    (and (n/right-edge-node? node|) (== pos (.-end parent)))
+                    (and (n/right-edge? node|) (== pos (.-end parent)))
                     {:cursor (dec pos)}
 
                     ;; inside left edge of collection - remove or stop
-                    (and (n/left-edge-node? node|) (== (.-start node|) (.-start parent)))
+                    (and (or (n/start-edge? node|)
+                             (n/same-edge? node|)) (== (.-start node|) (.-start parent)))
                     (if (n/empty? (n/up node|))
                       ;; remove empty collection
                       {:cursor (.-start parent)
@@ -88,8 +89,8 @@
                                    (.iterate (n/tree state)
                                              #js{:from (inc head)
                                                  :enter (fn [node-type start end]
-                                                          (if (or (n/prop node-type n/end-edge-prop)
-                                                                  (n/prop node-type n/same-edge-prop))
+                                                          (if
+                                                            (n/right-edge-type? node-type)
                                                             end
                                                             js/undefined))}))]
         {:cursor close-node-end}

--- a/src/main/codemirror_next/clojure/extensions/close_brackets.cljs
+++ b/src/main/codemirror_next/clojure/extensions/close_brackets.cljs
@@ -83,18 +83,27 @@
 (defn handle-close [state key-name]
   (u/update-ranges state
     (j/fn [^:js {:as range :keys [empty head]}]
-      ;; TODO
-      ;; allow insertion of closing-paren to fix unbalanced collection
-      (if-let [close-node-end (and empty
-                                   (.iterate (n/tree state)
-                                             #js{:from (inc head)
-                                                 :enter (fn [node-type start end]
-                                                          (if
-                                                            (n/right-edge-type? node-type)
-                                                            end
-                                                            js/undefined))}))]
-        {:cursor close-node-end}
-        (u/insertion head key-name)))))
+      (or (let [unbalanced (some->
+                             (n/tree state head -1)
+                             (n/ancestors)
+                             (->> (filter (every-pred n/coll? (complement n/balanced?))))
+                             first)
+                closing (some-> unbalanced n/down n/closed-by)
+                pos (n/end unbalanced)]
+            (when (and closing (= closing key-name))
+              {:changes {:from pos
+                         :insert closing}
+               :cursor (inc pos)}))
+          (when-let [close-node-end (and empty
+                                         (.iterate (n/tree state)
+                                                   #js{:from (inc head)
+                                                       :enter (fn [node-type start end]
+                                                                (if
+                                                                  (n/right-edge-type? node-type)
+                                                                  end
+                                                                  js/undefined))}))]
+            {:cursor close-node-end})
+          (u/insertion head key-name)))))
 
 (def extension
   (.domEventHandlers view/EditorView

--- a/src/main/codemirror_next/clojure/extensions/formatting.cljs
+++ b/src/main/codemirror_next/clojure/extensions/formatting.cljs
@@ -24,7 +24,7 @@
     (cond (= "Program" type-name)
           0
 
-          (node/coll-name? type-name)
+          (.prop type node/coll-prop)
           (let [left-bracket-end (.. node -firstChild -end)]
             (cond-> (.column context left-bracket-end)
               ;; start at the inner-left edge of the coll.
@@ -69,10 +69,18 @@
                      :to (+ from current-indent)})))))))
 
 (defn expected-space [n1 n2]
-  (cond (n/right-edges n2) 0
-        (n/left-edges n1) 0
-        (identical? n1 "KeywordPrefix") 0
-        :else 1))
+  (cond
+
+    ;; left-edges
+    (.prop n1 n/start-edge-prop) 0
+    (.prop n1 n/same-edge-prop) 0
+    (.prop n1 n/prefix-edge-prop) 0
+
+    ;; right-edges
+    (.prop n2 n/end-edge-prop) 0
+    (.prop n2 n/same-edge-prop) 0
+
+    :else 1))
 
 (defn space-changes [state from to]
   (->> (n/terminal-nodes (.-tree state) to from)

--- a/src/main/codemirror_next/clojure/extensions/formatting.cljs
+++ b/src/main/codemirror_next/clojure/extensions/formatting.cljs
@@ -71,8 +71,10 @@
 (defn expected-space [n1 n2]
   (if
     (or
-      (n/left-edge-type? n1)
-      (n/right-edge-type? n2))
+      (n/start-edge-type? n1)
+      (n/prefix-edge-type? n1)
+      (n/end-edge-type? n2)
+      (n/same-edge-type? n2))
     0
     1))
 

--- a/src/main/codemirror_next/clojure/extensions/formatting.cljs
+++ b/src/main/codemirror_next/clojure/extensions/formatting.cljs
@@ -69,18 +69,12 @@
                      :to (+ from current-indent)})))))))
 
 (defn expected-space [n1 n2]
-  (cond
-
-    ;; left-edges
-    (.prop n1 n/start-edge-prop) 0
-    (.prop n1 n/same-edge-prop) 0
-    (.prop n1 n/prefix-edge-prop) 0
-
-    ;; right-edges
-    (.prop n2 n/end-edge-prop) 0
-    (.prop n2 n/same-edge-prop) 0
-
-    :else 1))
+  (if
+    (or
+      (n/left-edge-type? n1)
+      (n/right-edge-type? n2))
+    0
+    1))
 
 (defn space-changes [state from to]
   (->> (n/terminal-nodes (.-tree state) to from)

--- a/src/main/codemirror_next/clojure/keymap.cljs
+++ b/src/main/codemirror_next/clojure/keymap.cljs
@@ -102,7 +102,7 @@
 
 (def paredit-keymap
   {:indent
-   [{:key "Alt-Tab"
+   [{:key "Tab"
      :doc "Indent document (or selection)"}]
    :unwrap
    [{:key "Alt-s"

--- a/src/main/codemirror_next/clojure/node.cljs
+++ b/src/main/codemirror_next/clojure/node.cljs
@@ -17,16 +17,14 @@
 ;; the prefix edge itself
 (defonce prefix-edge-prop (.flag lz-tree/NodeProp))
 ;; edges at the beginning/end of collections, + "same" edges (string quotes)
-(defonce start-edge-prop (.flag lz-tree/NodeProp))
-(defonce end-edge-prop (.flag lz-tree/NodeProp))
+(defonce start-edge-prop (.-closedBy lz-tree/NodeProp))
+(defonce end-edge-prop (.-openedBy lz-tree/NodeProp))
 (defonce same-edge-prop (.flag lz-tree/NodeProp))
 
 ;; used when instantiating the parser
 (defn node-prop [prop-name]
   (case prop-name "prefixColl" prefix-coll-prop
                   "coll" coll-prop
-                  "startEdge" start-edge-prop
-                  "endEdge" end-edge-prop
                   "prefixEdge" prefix-edge-prop
                   "sameEdge" same-edge-prop))
 

--- a/src/main/codemirror_next/clojure/node.cljs
+++ b/src/main/codemirror_next/clojure/node.cljs
@@ -13,7 +13,7 @@
 ;; primitive collection
 (defonce coll-prop (.flag lz-tree/NodeProp))
 ;; prefix collection - a prefix token that wraps the next element
-(defonce prefix-prop (.flag lz-tree/NodeProp))
+(defonce prefix-coll-prop (.flag lz-tree/NodeProp))
 ;; the prefix edge itself
 (defonce prefix-edge-prop (.flag lz-tree/NodeProp))
 ;; edges at the beginning/end of collections, + "same" edges (string quotes)
@@ -23,7 +23,7 @@
 
 ;; used when instantiating the parser
 (defn node-prop [prop-name]
-  (case prop-name "prefix" prefix-prop
+  (case prop-name "prefixColl" prefix-coll-prop
                   "coll" coll-prop
                   "startEdge" start-edge-prop
                   "endEdge" end-edge-prop
@@ -54,9 +54,9 @@
 ;; category predicates
 
 (defn coll-type? [^js node-type]
-  (or (.prop node-type coll-prop) (.prop node-type prefix-prop)))
+  (or (.prop node-type coll-prop) (.prop node-type prefix-coll-prop)))
 
-(defn ^boolean prefix-type? [node-type] (.prop ^js node-type prefix-prop))
+(defn ^boolean prefix-type? [node-type] (.prop ^js node-type prefix-coll-prop))
 (defn ^boolean prefix-edge-type? [node-type] (.prop ^js node-type prefix-edge-prop))
 (defn ^boolean same-edge-type? [node-type] (.prop ^js node-type same-edge-prop))
 (defn ^boolean start-edge-type? [node-type] (.prop ^js node-type start-edge-prop))
@@ -110,7 +110,7 @@
 
 (defn terminal-type? [^js node-type]
   (cond (.prop node-type (.-top lz-tree/NodeProp)) false
-        (.prop node-type prefix-prop) false
+        (.prop node-type prefix-coll-prop) false
         (.prop node-type coll-prop) false
         :else true))
 

--- a/src/main/codemirror_next/test_utils.cljs
+++ b/src/main/codemirror_next/test_utils.cljs
@@ -42,7 +42,9 @@
 (comment
  (-> (make-state #js[] "<a>b|c<d\n>a<b>c|")
      (state-str)
-     (= "<a>b|c<d\n>a<b>c|")))
+     (= "<a>b|c<d\n>a<b>c|"))
+
+ )
 
 (defn apply-cmd [extensions cmd doc]
   (let [state (make-state extensions doc)

--- a/src/test/codemirror_next/clojure_tests.cljs
+++ b/src/test/codemirror_next/clojure_tests.cljs
@@ -139,10 +139,6 @@
     "#(|a )" "#(|a)"
 
 
-    ;; not exactly desired, side effect of # being a prefix,
-    ;; also not that bad because this is invalid anyway.
-    "#| []" "#|[]"
-
     "|@ a" "|@a"
 
     ))

--- a/src/test/codemirror_next/clojure_tests.cljs
+++ b/src/test/codemirror_next/clojure_tests.cljs
@@ -9,8 +9,8 @@
 ;; TODO
 ;; set up testing flow
 
-(def apply-f (partial test-utils/apply-f cm-clojure/default-extensions))
-(def apply-cmd (partial test-utils/apply-cmd cm-clojure/default-extensions))
+(def apply-f (partial test-utils/apply-f cm-clojure/clj-extensions))
+(def apply-cmd (partial test-utils/apply-cmd cm-clojure/clj-extensions))
 
 
 (deftest nav

--- a/src/test/codemirror_next/clojure_tests.cljs
+++ b/src/test/codemirror_next/clojure_tests.cljs
@@ -75,6 +75,7 @@
     "@|" "|"                                                ;; delete @
     "@|x" "|x"
     "\"|\"" "|"                                             ;; delete empty string
+    "\"\"|" "\"|\""
     "\"| \"" "\"| \""                                             ;; do not delete string with whitespace
     ":x  :a |" ":x  :a|"                                    ;; do not format on backspace
     ))

--- a/src/test/codemirror_next/clojure_tests.cljs
+++ b/src/test/codemirror_next/clojure_tests.cljs
@@ -122,6 +122,7 @@
     (= (apply-f indent/format-all input)
        expected)
     "a  :b  3 |" "a :b 3 |"                                 ;; remove extra spaces
+    "\"\" |:a " "\"\" |:a "
     "(|a )" "(|a)"
     "| ( )" "|()"
     "|()a" "|() a"                                          ;; add needed spaces

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,10 +337,10 @@ lezer-css@^0.10.0:
   dependencies:
     lezer "^0.10.0"
 
-lezer-generator@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/lezer-generator/-/lezer-generator-0.10.3.tgz#47d68c0c40906d07e6dae8ab2215e83dc98be137"
-  integrity sha512-eReyY0cpM8mdyMUM+MsM6zNXExvY6lxVONgWBZHIG1Wg01gsMreoEe81drRdDOWOCAen+XMl8KJJFEs8XgcpZg==
+lezer-generator@0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/lezer-generator/-/lezer-generator-0.10.4.tgz#2304cc867e9982b5be246c7dc5ce6c1db3eb0bd6"
+  integrity sha512-fA3UNR0Q/XtY8gO/yzzEmj6RPCIL+7+Vi7GJDi2SqzkRHefe4whZGmbiWJ9ZbJXLrgorsn2SmEPQC9VOHnAWlg==
   dependencies:
     lezer "^0.10.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,10 +337,10 @@ lezer-css@^0.10.0:
   dependencies:
     lezer "^0.10.0"
 
-lezer-generator@0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/lezer-generator/-/lezer-generator-0.10.2.tgz#fff122b4ba105810a0ec07eebfced5df72ace836"
-  integrity sha512-/ly2la2epz5QjyQMpwy3+wriQ1yE8dKcu9xOLZMt8/GMQCBHtPjFVhv5gyNIFjp+rbbAYBf5y/qWyq3Y5hVpvQ==
+lezer-generator@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/lezer-generator/-/lezer-generator-0.10.3.tgz#47d68c0c40906d07e6dae8ab2215e83dc98be137"
+  integrity sha512-eReyY0cpM8mdyMUM+MsM6zNXExvY6lxVONgWBZHIG1Wg01gsMreoEe81drRdDOWOCAen+XMl8KJJFEs8XgcpZg==
   dependencies:
     lezer "^0.10.1"
 


### PR DESCRIPTION
Introduces 6 external node props that facilitate structural editing. To the extent possible, the grammar is the source of truth for information relevant to editing. I was able to remove a lot of code that was duplicating information from the grammar into sets.

`prefixColl` -> a collection consisting of a prefix token + a child
`prefixEdge` -> the token beginning a prefix collection
`coll` -> a primitive collection
`startEdge` -> the left edge of a primitive collection
`endEdge` -> the right edge of a primitive collection
`sameEdge` -> an edge that can be on the left or right (currently only strings)

also:

- allow closing of unmatched collections