### PR TITLE
Upgrade shadow, squint and clerk

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,18 @@
 {:paths ["src-shared" "src"]
  :deps {applied-science/js-interop {:mvn/version "0.3.3"}
-        org.clojure/clojure {:mvn/version "1.10.3"}
-        org.clojure/clojurescript {:mvn/version "1.10.866"}}
+        org.clojure/clojure {:mvn/version "1.12.0"}
+        org.clojure/clojurescript {:mvn/version "1.11.132"}}
  :aliases
  {:dev {:extra-paths ["test"]
-        :extra-deps {thheller/shadow-cljs {:mvn/version "2.14.4"}}}
+        :extra-deps {thheller/shadow-cljs {:mvn/version "2.28.20"}}}
 
   :demo {:extra-paths ["demo/src" "demo/notebooks"]
          :jvm-opts ["-Dpolyglot.engine.WarnInterpreterOnly=false"]
          :extra-deps {org.babashka/sci {:mvn/version "0.3.5"}
                       reagent/reagent {:mvn/version "1.1.1"}
                       io.github.nextjournal/clerk {#_#_ :local/root "../clerk"
-                                                   :git/sha "2fbd6f08fea2f736faae2e0cc46c435dce8a23f0"}
+                                                   #_#_:git/sha "2fbd6f08fea2f736faae2e0cc46c435dce8a23f0"
+                                                   :mvn/version "0.17.1102"}
                       ;; clerk dev deps
                       io.github.babashka/sci.configs {:git/sha "ec570cdfb2c627d0cd280a899cd915d0e89d8f7b"}
                       io.github.nextjournal/viewers {:git/sha "f4a32b05ff4382a85a3dcf66cdec89c2389ac3c8"

--- a/deps.edn
+++ b/deps.edn
@@ -11,8 +11,8 @@
          :extra-deps {org.babashka/sci {:mvn/version "0.3.5"}
                       reagent/reagent {:mvn/version "1.1.1"}
                       io.github.nextjournal/clerk {#_#_ :local/root "../clerk"
-                                                   #_#_:git/sha "2fbd6f08fea2f736faae2e0cc46c435dce8a23f0"
-                                                   :mvn/version "0.17.1102"}
+                                                   :git/sha "2fbd6f08fea2f736faae2e0cc46c435dce8a23f0"
+                                                   #_#_:mvn/version "0.17.1102"}
                       ;; clerk dev deps
                       io.github.babashka/sci.configs {:git/sha "ec570cdfb2c627d0cd280a899cd915d0e89d8f7b"}
                       io.github.nextjournal/viewers {:git/sha "f4a32b05ff4382a85a3dcf66cdec89c2389ac3c8"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@lezer/lr": "^1.0.0",
     "@nextjournal/lezer-clojure": "1.0.0",
     "markdown-it-footnote": "^3.0.3",
-    "squint-cljs": "0.8.128",
+    "squint-cljs": "0.8.129",
     "w3c-keyname": "^2.2.4"
   },
   "comments": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0",
     "@nextjournal/lezer-clojure": "1.0.0",
-    "squint-cljs": "0.7.111",
+    "markdown-it-footnote": "^3.0.3",
+    "squint-cljs": "0.8.128",
     "w3c-keyname": "^2.2.4"
   },
   "comments": {
@@ -59,6 +60,7 @@
   },
   "exports": {
     ".": "./dist/nextjournal/clojure_mode.mjs",
-    "./extensions/eval-region": "./dist/nextjournal/clojure_mode/extensions/eval_region.mjs"
+    "./extensions/eval-region": "./dist/nextjournal/clojure_mode/extensions/eval_region.mjs",
+    "./extensions/formatting": "./dist/nextjournal/clojure_mode/extensions/formatting.mjs"
   }
 }

--- a/public/squint/index.html
+++ b/public/squint/index.html
@@ -436,7 +436,7 @@
     <script type="importmap">
    {
      "imports": {
-       "squint-cljs/core.js": "https://unpkg.com/squint-cljs@0.4.81/core.js"
+       "squint-cljs/core.js": "https://unpkg.com/squint-cljs@0.8.128/core.js"
      }
    }
     </script>

--- a/public/squint/index.html
+++ b/public/squint/index.html
@@ -436,7 +436,7 @@
     <script type="importmap">
    {
      "imports": {
-       "squint-cljs/core.js": "https://unpkg.com/squint-cljs@0.8.128/core.js"
+       "squint-cljs/core.js": "https://unpkg.com/squint-cljs@0.8.129/core.js"
      }
    }
     </script>

--- a/src-shared/nextjournal/clojure_mode.cljc
+++ b/src-shared/nextjournal/clojure_mode.cljc
@@ -21,22 +21,23 @@
       :List coll-span})))
 
 (def style-tags
-  (clj->js {:NS (.-keyword tags)
-            :DefLike (.-keyword tags)
-            "Operator/Symbol" (.-keyword tags)
-            "VarName/Symbol" (.definition tags (.-variableName tags))
-            :Boolean (.-atom tags)
-            "DocString/..." (.-emphasis tags)
-            :Discard! (.-comment tags)
-            :Number (.-number tags)
-            :StringContent (.-string tags)
-            ;; need to pass something, that returns " when being parsed as JSON
-            ;; also #js doesn't treat this correctly, hence clj->js above
-            "\"\\\"\"" (.-string tags)
-            :Keyword (.-atom tags)
-            :Nil (.-null tags)
-            :LineComment (.-lineComment tags)
-            :RegExp (.-regexp tags)}))
+  (clj->js
+   {:NS (.-keyword tags)
+    :DefLike (.-keyword tags)
+    "Operator/Symbol" (.-keyword tags)
+    "VarName/Symbol" (.definition tags (.-variableName tags))
+    :Boolean (.-atom tags)
+    "DocString/..." (.-emphasis tags)
+    :Discard! (.-comment tags)
+    :Number (.-number tags)
+    :StringContent (.-string tags)
+    ;; need to pass something, that returns " when being parsed as JSON
+    ;; also #js doesn't treat this correctly, hence clj->js above
+    "\"\\\"\"" (.-string tags)
+    :Keyword (.-atom tags)
+    :Nil (.-null tags)
+    :LineComment (.-lineComment tags)
+    :RegExp (.-regexp tags)}))
 
 (def parser lezer-clj/parser)
 

--- a/src-shared/nextjournal/clojure_mode/util.cljc
+++ b/src-shared/nextjournal/clojure_mode/util.cljc
@@ -58,7 +58,8 @@
                 from-to
                 range
                 changes]} (guard update-map map?)
-        change-desc (when changes (.changes state (clj->js changes)))]
+        change-desc (when changes (.changes state (-> changes
+                                                      clj->js)))]
     (cond-> #js{:range (or range
                            (cond mapped (sel/cursor (.mapPos change-desc mapped))
                                  cursor (sel/cursor cursor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,14 +321,6 @@
   resolved "https://registry.yarnpkg.com/@squint-cljs/macros/-/macros-0.1.0.tgz#38259e429222c8f01acc93f3eae3df8a2e10f24c"
   integrity sha512-VVwgcprJxItnITWZA5n32iUCI41S9n5WiZCQrC2uh314L/MU+7w3E7cjCp+mBygKhJL80U1VCFchY9ra1Z+6Zg==
 
-anymatch@~3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
-  integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
-  dependencies:
-    normalize-path "^3.0.0"
-    picomatch "^2.0.4"
-
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
@@ -356,11 +348,6 @@ base64-js@^1.0.2:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
-binary-extensions@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
-  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -370,13 +357,6 @@ bn.js@^5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz"
   integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
-
-braces@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
-  dependencies:
-    fill-range "^7.0.1"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -463,20 +443,12 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-chokidar@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+chokidar@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.1.tgz#4a6dff66798fb0f72a94f616abbd7e1a19f31d41"
+  integrity sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==
   dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
+    readdirp "^4.0.1"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -650,13 +622,6 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
-
 framer-motion@^6.2.8:
   version "6.3.16"
   resolved "https://registry.npmjs.org/framer-motion/-/framer-motion-6.3.16.tgz"
@@ -681,13 +646,6 @@ fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
-  dependencies:
-    is-glob "^4.0.1"
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -745,30 +703,6 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-is-binary-path@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
-  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  dependencies:
-    binary-extensions "^2.0.0"
-
-is-extglob@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
-
-is-glob@^4.0.1, is-glob@~4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
-  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
-  dependencies:
-    is-extglob "^2.1.1"
-
-is-number@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
-  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
@@ -809,6 +743,11 @@ markdown-it-block-image@0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/markdown-it-block-image/-/markdown-it-block-image-0.0.3.tgz"
   integrity sha512-+esbdLegMSWmIRGwVncj5ZwVi5K1qt894uXfnkZIyMFC7ssbv7aR7YEVI16w0PdFWow1HmBNUZ4chl0vScjoIA==
+
+markdown-it-footnote@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz#e0e4c0d67390a4c5f0c75f73be605c7c190ca4d8"
+  integrity sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==
 
 "markdown-it-sidenote@https://github.com/gerwitz/markdown-it-sidenote#aa5de8ce3168b7d41cb33c3aed071a5f41ce0083":
   version "0.2.0"
@@ -901,11 +840,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-normalize-path@^3.0.0, normalize-path@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
-  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -953,11 +887,6 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
-
-picomatch@^2.0.4, picomatch@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 popmotion@11.0.3:
   version "11.0.3"
@@ -1079,12 +1008,10 @@ readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdirp@~3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
-  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
-  dependencies:
-    picomatch "^2.2.1"
+readdirp@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.2.tgz#388fccb8b75665da3abffe2d8f8ed59fe74c230a"
+  integrity sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==
 
 readline-sync@^1.4.7:
   version "1.4.10"
@@ -1176,12 +1103,12 @@ source-map@^0.5.6:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-squint-cljs@0.7.111:
-  version "0.7.111"
-  resolved "https://registry.yarnpkg.com/squint-cljs/-/squint-cljs-0.7.111.tgz#1441933ed7162d5590570875394c12b181db9427"
-  integrity sha512-BZSq3OxqdRN1xpIYBOWDI03tppaOLxtmapUDsS32ViKg2anu6fo44qh3qGAvXcapDwc1mkIS6A2y2GA+SgB2Rw==
+squint-cljs@0.8.128:
+  version "0.8.128"
+  resolved "https://registry.yarnpkg.com/squint-cljs/-/squint-cljs-0.8.128.tgz#9ef9a98ab89e568eee339fd01a24479049523ac4"
+  integrity sha512-+5MQORcOpGEPE4gDWafrwSpdlsxfWHYMyQEwrF9jdy5g12TmkKe9qe/OVoFLc6325P/jKeof/xjnbiXGHjfr7A==
   dependencies:
-    chokidar "^3.5.3"
+    chokidar "^4.0.1"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -1240,13 +1167,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
-to-regex-range@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
-  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
-  dependencies:
-    is-number "^7.0.0"
 
 tslib@^2.1.0:
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,10 +1103,10 @@ source-map@^0.5.6:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-squint-cljs@0.8.128:
-  version "0.8.128"
-  resolved "https://registry.yarnpkg.com/squint-cljs/-/squint-cljs-0.8.128.tgz#9ef9a98ab89e568eee339fd01a24479049523ac4"
-  integrity sha512-+5MQORcOpGEPE4gDWafrwSpdlsxfWHYMyQEwrF9jdy5g12TmkKe9qe/OVoFLc6325P/jKeof/xjnbiXGHjfr7A==
+squint-cljs@0.8.129:
+  version "0.8.129"
+  resolved "https://registry.yarnpkg.com/squint-cljs/-/squint-cljs-0.8.129.tgz#04a3f1ca899e6fb7e2ba30b882efb791741caff0"
+  integrity sha512-cgTKzOorBX2wuli+6BNnioPYslAqyGP+C4W5W/B2ddlBXCTUPfc9nCrxkz5hP1vOt6bPJNZDdKjcXkfRlO62/g==
   dependencies:
     chokidar "^4.0.1"
 


### PR DESCRIPTION
In the newest squint, clj->js became a function instead of a no-op in the compiler.

While upgrading squint here in clojure-mode, I checked the performance implications of running `clj->js` over data structures but it seems to be very very minimal, so I'll leave those calls in for squint as well. 

I ran into an issue with shadow which didn't run anymore on my machine with JDK21+, so I upgraded that as well.

Furthermore I exported one more file which I needed for some experiment (replacing standard clojure style with the formatting provided by this library).